### PR TITLE
Include region info in data items of rwset

### DIFF
--- a/xactserver/src/xact.rs
+++ b/xactserver/src/xact.rs
@@ -205,11 +205,13 @@ impl RWSetHeader {
 enum Relation {
     Table {
         oid: u32,
+        region: u8,
         csn: u32,
         tuples: Vec<Tuple>,
     },
     Index {
         oid: u32,
+        region: u8,
         pages: Vec<Page>,
     },
 }
@@ -239,6 +241,7 @@ impl Relation {
 
     fn decode_table(buf: &mut Bytes) -> anyhow::Result<Relation> {
         let relid = get_u32(buf).context("Failed to decode 'relid'")?;
+        let region = get_u8(buf).context("Failed to decode 'region'")?;
         let ntuples = get_u32(buf).context("Failed to decode 'ntuples'")?;
         let csn = get_u32(buf).context("Failed to decode 'csn'")?;
         let mut tuples = vec![];
@@ -250,6 +253,7 @@ impl Relation {
 
         Ok(Relation::Table {
             oid: relid,
+            region,
             csn,
             tuples,
         })
@@ -264,6 +268,7 @@ impl Relation {
 
     fn decode_index(buf: &mut Bytes) -> anyhow::Result<Relation> {
         let relid = get_u32(buf).context("Failed to decode 'relid'")?;
+        let region = get_u8(buf).context("Failed to decode 'region")?;
         let npages = get_u32(buf).context("Failed to decode 'npages'")?;
         let mut pages = vec![];
         for _ in 0..npages {
@@ -272,7 +277,7 @@ impl Relation {
             })?);
         }
 
-        Ok(Relation::Index { oid: relid, pages })
+        Ok(Relation::Index { oid: relid, region, pages })
     }
 
     fn decode_page(buf: &mut Bytes) -> anyhow::Result<Page> {


### PR DESCRIPTION
In the following transaction, `t1` is set to region 1.
```sql
begin transaction isolation level serializable;
select * from t1;
insert into t1 values (99);
commit;
```

The rwset now has region information in individual relations and writes:
```json
{
        "header": { "dbid": 13008, "xid": 0, "region_set": 2 },
        "relations": [
                {"relid": 16384, "region": 1, "is_index": 0, "csn": 1}
        ],
        "writes": [
                {"action": "INSERT", "relid": 16384, "region": 1,
                 "new_tuple": {"ncols": 1, "status": "b", "colsizes": [4]}}
        ]
}
```