### PR TITLE
Make node-id 1-based

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2384,6 +2384,7 @@ dependencies = [
  "clap 3.2.7",
  "env_logger",
  "futures",
+ "lazy_static",
  "log",
  "prost",
  "tokio",

--- a/xactserver/Cargo.toml
+++ b/xactserver/Cargo.toml
@@ -12,6 +12,7 @@ bytes = { version = "1.0.1", features = ["serde"] }
 clap = { version = "3.2.7", features = ["derive"] }
 env_logger = "0.9.0"
 futures = "0.3.17"
+lazy_static = "1.4.0"
 log = "0.4.14"
 prost = "0.10"
 tonic = "0.7"

--- a/xactserver/src/lib.rs
+++ b/xactserver/src/lib.rs
@@ -10,11 +10,17 @@ pub use manager::XactManager;
 pub use node::Node;
 
 use bytes::Bytes;
+use lazy_static::lazy_static;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use tokio::sync::oneshot;
 
 pub type NodeId = usize;
 pub type XactId = u64;
 
+lazy_static! {
+    pub static ref DUMMY_ADDRESS: SocketAddr =
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
+}
 pub const NODE_ID_BITS: i32 = 10;
 
 #[derive(Debug)]

--- a/xactserver/src/manager.rs
+++ b/xactserver/src/manager.rs
@@ -11,7 +11,7 @@ use crate::node::client;
 use crate::pg::{LocalXactController, SurrogateXactController};
 use crate::proto::{PrepareRequest, Vote, VoteRequest};
 use crate::xact::{XactState, XactStatus};
-use crate::{NodeId, XactId, XsMessage, NODE_ID_BITS};
+use crate::{NodeId, XactId, XsMessage, DUMMY_ADDRESS, NODE_ID_BITS};
 
 pub struct XactManager {
     node_id: NodeId,
@@ -49,7 +49,13 @@ impl XactManager {
             client::Nodes::connect(
                 self.peer_addrs
                     .iter()
-                    .map(|addr| format!("http://{}", addr.to_string()))
+                    .map(|addr| {
+                        if addr == &*DUMMY_ADDRESS {
+                            String::default()
+                        } else {
+                            format!("http://{}", addr.to_string())
+                        }
+                    })
                     .collect(),
             )
             .await?,

--- a/xactserver/src/xact.rs
+++ b/xactserver/src/xact.rs
@@ -205,11 +205,13 @@ impl RWSetHeader {
 enum Relation {
     Table {
         oid: u32,
+        region: u8,
         csn: u32,
         tuples: Vec<Tuple>,
     },
     Index {
         oid: u32,
+        region: u8,
         pages: Vec<Page>,
     },
 }
@@ -239,6 +241,7 @@ impl Relation {
 
     fn decode_table(buf: &mut Bytes) -> anyhow::Result<Relation> {
         let relid = get_u32(buf).context("Failed to decode 'relid'")?;
+        let region = get_u8(buf).context("Failed to decode 'region'")?;
         let ntuples = get_u32(buf).context("Failed to decode 'ntuples'")?;
         let csn = get_u32(buf).context("Failed to decode 'csn'")?;
         let mut tuples = vec![];
@@ -250,6 +253,7 @@ impl Relation {
 
         Ok(Relation::Table {
             oid: relid,
+            region,
             csn,
             tuples,
         })
@@ -264,6 +268,7 @@ impl Relation {
 
     fn decode_index(buf: &mut Bytes) -> anyhow::Result<Relation> {
         let relid = get_u32(buf).context("Failed to decode 'relid'")?;
+        let region = get_u8(buf).context("Failed to decode 'region")?;
         let npages = get_u32(buf).context("Failed to decode 'npages'")?;
         let mut pages = vec![];
         for _ in 0..npages {
@@ -272,7 +277,7 @@ impl Relation {
             })?);
         }
 
-        Ok(Relation::Index { oid: relid, pages })
+        Ok(Relation::Index { oid: relid, region, pages })
     }
 
     fn decode_page(buf: &mut Bytes) -> anyhow::Result<Page> {


### PR DESCRIPTION
The regions are numbered and region 0 is reserved for the special "global region", thus other regions start from 1.
We need to match this scheme with how the xact server nodes are numbered.
The `--node-id` flag is used to index into the list of addresses `--nodes`. Now that we make `--node-id` 1-based, we need to add a dummy value at the start of `--nodes`.
