### PR TITLE
General changes to support applying writes from remote xact

### DIFF
--- a/xactserver/src/node.rs
+++ b/xactserver/src/node.rs
@@ -55,7 +55,7 @@ impl XactCoordination for Node {
 }
 
 pub mod client {
-    use anyhow::anyhow;
+    use anyhow::{anyhow, ensure};
     use async_trait::async_trait;
     use futures::stream::{self, StreamExt, TryStreamExt};
 
@@ -82,9 +82,10 @@ pub mod client {
             &self,
             id: NodeId,
         ) -> anyhow::Result<bb8::PooledConnection<'_, ConnectionManager>> {
+            ensure!(id > 0, "Node id must be positive");
             let pool = self.conn_pools.get(id as usize).ok_or_else(|| {
                 anyhow!(
-                    "Node id {} is out of range (0 - {})",
+                    "Node id {} is out of range (1 - {})",
                     id,
                     self.conn_pools.len()
                 )

--- a/xactserver/src/pg/xact_controller.rs
+++ b/xactserver/src/pg/xact_controller.rs
@@ -93,7 +93,7 @@ impl XactController for SurrogateXactController {
         let client = self.client.get_or_insert(client);
         // TODO: Not doing anything for now
         client
-            .execute("SELECT print_bytes($1::bytea);", &[&self.data.as_ref()])
+            .execute("SELECT validate_and_apply_xact($1::bytea);", &[&self.data.as_ref()])
             .await
             .context("Failed to print bytes")?;
         Ok(true)

--- a/xactserver/src/xact.rs
+++ b/xactserver/src/xact.rs
@@ -315,6 +315,7 @@ mod tests {
 
     use super::*;
 
+    /// A fake controllers that trivially keeps track of transaction states
     struct TestXactController {
         rollback_on_execution: bool,
         executed: bool,
@@ -349,12 +350,12 @@ mod tests {
     }
 
     fn new_test_xact_state(
-        parts: Vec<NodeId>,
+        participants: Vec<NodeId>,
         rollback_on_execution: bool,
     ) -> XactState<TestXactController> {
-        let mut participants = BitSet::new();
-        for p in parts {
-            participants.insert(p);
+        let mut participant_set = BitSet::new();
+        for p in participants {
+            participant_set.insert(p);
         }
         XactState {
             id: 100,
@@ -366,7 +367,7 @@ mod tests {
                 rollbacked: false,
             },
             status: XactStatus::Uninitialized,
-            participants,
+            participants: participant_set,
             voted: BitSet::new(),
         }
     }


### PR DESCRIPTION
+ Switch to using `validate_and_apply_xact`.
+ Make sure that region 0, which is a special "global" region, is not used in the xact server