### PR TITLE
More flexible addressing in the arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,6 +758,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +871,12 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "matchit"
@@ -2104,6 +2131,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "url"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fe195a4f217c25b25cb5058ced57059824a678474874038dc88d211bf508d3"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "utils"
 version = "0.1.0"
 source = "git+https://github.com/neondatabase/neon.git#4a05413a4c5ada72cb1bb99809bc4cdea482165d"
@@ -2394,5 +2432,6 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tonic-build",
+ "url",
  "utils",
 ]

--- a/xactserver/Cargo.toml
+++ b/xactserver/Cargo.toml
@@ -20,6 +20,7 @@ tokio = { version = "1.19.2", features = ["rt-multi-thread", "macros", "sync"] }
 tokio-stream = "0.1"
 neon_utils = { git = "https://github.com/neondatabase/neon.git", package = "utils" }
 tokio_postgres = { git = "https://github.com/neondatabase/rust-postgres.git", branch = "neon", package = "tokio-postgres" }
+url = "2.2.2"
 
 [build-dependencies]
 tonic-build = "0.7"

--- a/xactserver/src/lib.rs
+++ b/xactserver/src/lib.rs
@@ -6,22 +6,21 @@ mod proto {
     tonic::include_proto!("xactserver");
 }
 
+use lazy_static::lazy_static;
 pub use manager::XactManager;
 pub use node::Node;
 
 use bytes::Bytes;
-use lazy_static::lazy_static;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use tokio::sync::oneshot;
 
 pub type NodeId = usize;
 pub type XactId = u64;
 
 lazy_static! {
-    pub static ref DUMMY_ADDRESS: SocketAddr =
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
+    pub static ref DUMMY_URL: url::Url = url::Url::parse("http://0.0.0.0").unwrap();
 }
 pub const NODE_ID_BITS: i32 = 10;
+pub const DEFAULT_NODE_PORT: u16 = 23000;
 
 #[derive(Debug)]
 pub enum XsMessage {


### PR DESCRIPTION
Previously, we can only specify exact IP addresses. This PR allows us to specify the addresses as URLs, which is a lot more convenient in deployments. For example,

Before:
```
target/debug/xactserver \
  --connect-pg 127.0.0.1:55433 \
  --listen-pg 127.0.0.1:10000 \
  --node-id 1 \
  --nodes 127.0.0.1:23000,127.0.0.1:23001
```

After:

```
target/debug/xactserver \
  --connect-pg postgres://localhost:55433 \
  --listen-pg 127.0.0.1:10000 \
  --node-id 1 \
  --nodes http://xactserver1:23000,http://xactserver2:23000
```
