### PR TITLE
Postgres connection pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bb8-postgres"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ac82c42eb30889b5c4ee4763a24b8c566518171ebea648cd7e3bc532c60680"
+dependencies = [
+ "async-trait",
+ "bb8",
+ "tokio",
+ "tokio-postgres 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,6 +1162,24 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "878c6cbf956e03af9aa8204b407b9cbf47c072164800aa918c516cd4b056c50c"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.4"
 source = "git+https://github.com/neondatabase/rust-postgres.git?branch=neon#d052ee8b86fff9897c77b0fe89ea9daba0e1fa38"
 dependencies = [
  "base64",
@@ -1201,6 +1231,17 @@ dependencies = [
  "bytes",
  "fallible-iterator",
  "postgres-protocol 0.6.4 (git+https://github.com/zenithdb/rust-postgres.git?rev=d052ee8b86fff9897c77b0fe89ea9daba0e1fa38)",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73d946ec7d256b04dfadc4e6a3292324e6f417124750fc5c0950f981b703a0f1"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "postgres-protocol 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1850,6 +1891,29 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c88a47a23c5d2dc9ecd28fb38fba5fc7e5ddc1fe64488ec145076b0c71c8ae"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "postgres-types 0.2.4",
+ "socket2",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.6"
 source = "git+https://github.com/neondatabase/rust-postgres.git?branch=neon#d052ee8b86fff9897c77b0fe89ea9daba0e1fa38"
 dependencies = [
  "async-trait",
@@ -2419,6 +2483,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bb8",
+ "bb8-postgres",
  "bit-set",
  "bytes",
  "clap 3.2.7",

--- a/xactserver/Cargo.toml
+++ b/xactserver/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-bb8 = "0.8.0"
+bb8 = "0.8"
+bb8-postgres = "0.8"
 bit-set = "0.5.3"
 bytes = { version = "1.0.1", features = ["serde"] }
 clap = { version = "3.2.7", features = ["derive"] }

--- a/xactserver/src/lib.rs
+++ b/xactserver/src/lib.rs
@@ -6,12 +6,12 @@ mod proto {
     tonic::include_proto!("xactserver");
 }
 
+use bytes::Bytes;
 use lazy_static::lazy_static;
+use tokio::sync::oneshot;
+
 pub use manager::Manager;
 pub use node::Node;
-
-use bytes::Bytes;
-use tokio::sync::oneshot;
 
 pub type NodeId = usize;
 pub type XactId = u64;

--- a/xactserver/src/pg/mod.rs
+++ b/xactserver/src/pg/mod.rs
@@ -1,5 +1,36 @@
 mod watcher;
 mod xact_controller;
 
+use bb8::{ErrorSink, Pool};
+use bb8_postgres::{tokio_postgres::NoTls, PostgresConnectionManager};
+use log::error;
+
 pub use watcher::PgWatcher;
 pub use xact_controller::{LocalXactController, SurrogateXactController, XactController};
+
+pub type PgConnectionPool = Pool<PostgresConnectionManager<NoTls>>;
+
+#[derive(Debug, Clone, Copy)]
+pub struct PgErrorSink;
+
+type PgConnError = <PostgresConnectionManager<NoTls> as bb8::ManageConnection>::Error;
+
+impl ErrorSink<PgConnError> for PgErrorSink {
+    fn sink(&self, e: PgConnError) {
+        error!("{}", e);
+    }
+
+    fn boxed_clone(&self) -> Box<dyn ErrorSink<PgConnError>> {
+        Box::new(*self)
+    }
+}
+
+pub async fn create_pg_conn_pool(pg_url: &url::Url) -> anyhow::Result<PgConnectionPool> {
+    let pg_mgr = PostgresConnectionManager::new_from_stringlike(pg_url.to_string(), NoTls)?;
+    // TODO: expose settings for the connection pool
+    Ok(Pool::builder()
+        .max_size(50)
+        .error_sink(Box::new(PgErrorSink))
+        .build(pg_mgr)
+        .await?)
+}

--- a/xactserver/src/pg/xact_controller.rs
+++ b/xactserver/src/pg/xact_controller.rs
@@ -1,11 +1,11 @@
-use anyhow::{anyhow, bail, ensure, Context};
+use anyhow::{anyhow, bail, Context};
 use async_trait::async_trait;
+use bb8::PooledConnection;
+use bb8_postgres::{tokio_postgres::NoTls, PostgresConnectionManager};
 use bytes::Bytes;
-use log::{error, info};
 use tokio::sync::oneshot;
-use url::Url;
 
-use crate::XactId;
+use crate::{pg::PgConnectionPool, XactId};
 
 #[async_trait]
 pub trait XactController {
@@ -55,20 +55,18 @@ impl XactController for LocalXactController {
 
 pub struct SurrogateXactController {
     xact_id: XactId,
-    connect_pg: Url,
     data: Bytes,
-    client: Option<tokio_postgres::Client>,
-    prepared: bool,
+    pg_conn_pool: PgConnectionPool,
+    pg_conn: Option<PooledConnection<'static, PostgresConnectionManager<NoTls>>>,
 }
 
 impl SurrogateXactController {
-    pub fn new(xact_id: XactId, connect_pg: Url, data: Bytes) -> Self {
+    pub fn new(xact_id: XactId, data: Bytes, pg_conn_pool: PgConnectionPool) -> Self {
         Self {
             xact_id,
-            connect_pg,
             data,
-            client: None,
-            prepared: false,
+            pg_conn_pool,
+            pg_conn: None,
         }
     }
 }
@@ -76,92 +74,56 @@ impl SurrogateXactController {
 #[async_trait]
 impl XactController for SurrogateXactController {
     async fn execute(&mut self) -> anyhow::Result<()> {
-        // TODO: Use a connection pool
-        let conn_str = format!(
-            "host={} port={} user=cloud_admin dbname=postgres application_name=xactserver",
-            self.connect_pg
-                .host_str()
-                .ok_or_else(|| anyhow!("Invalid host in postgres url"))?,
-            self.connect_pg
-                .port()
-                .ok_or_else(|| anyhow!("Invalid port in postgres url"))?
-        );
-        info!("Connecting to local pg, conn str: {}", conn_str);
-        let (client, conn) = tokio_postgres::connect(&conn_str, tokio_postgres::NoTls).await?;
+        let conn = match self.pg_conn.take() {
+            Some(c) => c,
+            None => self.pg_conn_pool.get_owned().await?,
+        };
 
-        // The connection object performs the actual communication with the database,
-        // so spawn it off to run on its own.
-        tokio::spawn(async move {
-            if let Err(e) = conn.await {
-                error!("Connection error: {}", e);
-            }
-        });
-
-        let client = self.client.get_or_insert(client);
-        let xact_id = self.xact_id;
-
-        client
-            .simple_query("BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+        conn.simple_query("BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE")
             .await
-            .with_context(|| format!("Failed to begin xact {}", xact_id))?;
+            .with_context(|| format!("Failed to begin xact {}", self.xact_id))?;
 
-        client
-            .execute(
-                "SELECT validate_and_apply_xact($1::bytea);",
-                &[&self.data.as_ref()],
+        conn.execute(
+            "SELECT validate_and_apply_xact($1::bytea);",
+            &[&self.data.as_ref()],
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "Failed to execute validate_and_apply_xact($1::bytea) for xact {}",
+                self.xact_id
             )
-            .await
-            .with_context(|| {
-                format!(
-                    "Failed to execute validate_and_apply_xact($1::bytea) for xact {}",
-                    xact_id
-                )
-            })?;
+        })?;
 
-        client
-            .simple_query(format!("PREPARE TRANSACTION '{}'", self.xact_id).as_str())
+        conn.simple_query(format!("PREPARE TRANSACTION '{}'", self.xact_id).as_str())
             .await
-            .with_context(|| format!("Failed to prepare xact {}", xact_id))?;
+            .with_context(|| format!("Failed to prepare xact {}", self.xact_id))?;
 
-        self.prepared = true;
+        // Retain the connection to perform commit or rollback later
+        self.pg_conn = Some(conn);
 
         Ok(())
     }
 
     async fn commit(&mut self) -> anyhow::Result<()> {
-        // Must be prepared to commit
-        ensure!(self.prepared);
-
-        match &self.client {
-            Some(client) => {
-                client
-                    .simple_query(format!("COMMIT PREPARED '{}'", self.xact_id).as_str())
+        match &self.pg_conn {
+            Some(conn) => {
+                conn.simple_query(format!("COMMIT PREPARED '{}'", self.xact_id).as_str())
                     .await
                     .with_context(|| format!("Failed to commit xact {}", self.xact_id))?;
             }
             None => {
-                bail!("Connection does not exist");
+                bail!("No prepared transaction to commit");
             }
         }
         Ok(())
     }
 
     async fn rollback(&mut self) -> anyhow::Result<()> {
-        // Do nothing if it is not prepared
-        if !self.prepared {
-            return Ok(());
-        }
-
-        match &self.client {
-            Some(client) => {
-                client
-                    .simple_query(format!("ROLLBACK PREPARED '{}'", self.xact_id).as_str())
-                    .await
-                    .with_context(|| format!("Failed to roll back xact {}", self.xact_id))?;
-            }
-            None => {
-                bail!("Connection does not exist");
-            }
+        if let Some(conn) = &self.pg_conn {
+            conn.simple_query(format!("ROLLBACK PREPARED '{}'", self.xact_id).as_str())
+                .await
+                .with_context(|| format!("Failed to rollback xact {}", self.xact_id))?;
         }
         Ok(())
     }


### PR DESCRIPTION
Use a connection pool to connect from the transaction server to postgres. Tested and the "too many connections" error no longer occurred. Note that we need to specify more information in the url for the `connect-pg` , for example: `--connect-pg postgresql://cloud_admin@localhost:55433/postgres`. The wiki has been updated to reflect this.